### PR TITLE
Actually apply the configured connect timeout

### DIFF
--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -171,6 +171,7 @@ impl ClientBuilder {
         C::Error: Into<BoxError>,
     {
         let mut connector = TimeoutConnector::new(conn);
+        connector.set_connect_timeout(self.connect_timeout);
         connector.set_read_timeout(self.read_timeout);
 
         let client = hyper::Client::builder().build::<_, hyper::Body>(connector);


### PR DESCRIPTION
The `connect_timeout` introduced in https://github.com/MaterializeInc/rust-eventsource-client/pull/1 didn't actually get applied to the connection previously.